### PR TITLE
Change white black font algorithm

### DIFF
--- a/utils/color.js
+++ b/utils/color.js
@@ -1,20 +1,11 @@
 import chroma from 'chroma-js';
 
-const partialLuminance = value =>
-  value <= 0.03928 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4);
-
-export const getRelativeLuminance = hex => {
-  // https://www.w3.org/TR/WCAG20/#relativeluminancedef
+const getLuminance = hex => {
+  // https://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
   const [red, green, blue] = chroma(hex).rgb(false);
 
-  return (
-    0.2126 * partialLuminance(red / 255) +
-    0.7152 * partialLuminance(green / 255) +
-    0.0722 * partialLuminance(blue / 255)
-  );
+  return Math.sqrt(red ** 2 * 0.241 + green ** 2 * 0.691 + blue ** 2 * 0.068);
 };
 
 export const getFontWhiteOrBlack = backgroundHex =>
-  // Contrast is identical at 4.583, for both white and black font
-  // on background with relative luminance of 0.179
-  getRelativeLuminance(backgroundHex) < 0.179 ? 'white' : 'black';
+  getLuminance(backgroundHex) < 130 ? 'white' : 'black';


### PR DESCRIPTION
Change font color algorithm

Old algorithm follows WCAG2.0 [algorithm](https://www.w3.org/TR/WCAG20/#relativeluminancedef) which found to be unsatisfactory.

New algorithm follows a commonly used [algorithm](https://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx), albeit without WCAG backing.